### PR TITLE
Route default-locale writes to the model, add forgetTranslation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-translatable` will be documented in this file.
 
 ## [Unreleased] - 2024-XX-XX
 
+### Write API
+
+- **NEW**: `forgetTranslation($key, $locale)` — removes a translation row; for the default locale (with `default_locale_on_model`) it nulls the model attribute instead
+- **CHANGED**: `setTranslation()` accepts `null` to remove a translation
+- **CHANGED**: with `default_locale_on_model` enabled, `setTranslation()`/`setTranslations()` write the default locale to the model attribute (persisted on the next `save()`) instead of creating a translation row that is never read
+
 ### 🎉 Major Features Added
 
 #### Scope-Based Architecture

--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ $product->setTranslations([
     'title' => 'English Product',
     'description' => 'English Description',
 ], 'en');
+
+// A null value removes the translation, as does forgetTranslation()
+$product->setTranslation('title', null, 'fr');
+$product->forgetTranslation('description', 'fr');
 ```
+
+With `default_locale_on_model` enabled, writes for the default locale are routed to the
+model's own attribute instead of a translation row (rows for the default locale are never
+read) — they persist with the model's next `save()`.
 
 ### 3. Automatic Translation Override
 
@@ -335,8 +343,9 @@ class Article extends Model
 
 | Method | Description | Parameters |
 |--------|-------------|------------|
-| `setTranslation($key, $value, $locale)` | Set translation for a field | `string $key`, `string $value`, `?string $locale` |
+| `setTranslation($key, $value, $locale)` | Set translation for a field; null removes it | `string $key`, `?string $value`, `?string $locale` |
 | `setTranslations($translations, $locale)` | Set multiple translations at once | `array $translations`, `?string $locale` |
+| `forgetTranslation($key, $locale)` | Remove translation for a field | `string $key`, `?string $locale` |
 | `getTranslation($key, $locales)` | Get translated text with fallback | `string $key`, `string\|array\|null $locales` |
 | `getTranslations($key, $locales)` | Get translations as array | `string $key`, `string\|array\|null $locales` |
 | `getAllTranslations($key)` | Get all translations for a key | `string $key` |

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
             "@composer run build",
             "@php vendor/bin/testbench serve"
         ],
-        "analyse": "vendor/bin/phpstan analyse",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=2G",
         "test": "vendor/bin/pest --no-coverage",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"

--- a/src/Scopes/TranslatableScope.php
+++ b/src/Scopes/TranslatableScope.php
@@ -3,7 +3,6 @@
 namespace mindtwo\LaravelTranslatable\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Scope;
 use mindtwo\LaravelTranslatable\Resolvers\LocaleResolver;
 
@@ -69,7 +68,7 @@ class TranslatableScope implements Scope
             }
 
             return $query->with([
-                'translations' => fn (MorphMany $q) => $q->whereIn('locale', $locales),
+                'translations' => fn ($q) => $q->whereIn('locale', $locales),
             ])->afterQuery(fn ($results) => $results->each(fn ($result) => $result->addLoadedLocales($locales)));
         });
 
@@ -90,37 +89,7 @@ class TranslatableScope implements Scope
             string $operator = 'like',
             string $boolean = 'and',
         ) {
-            $localePriority = resolve(LocaleResolver::class)->normalizeLocales($locales);
-
-            $searchValue = match ($operator) {
-                'like' => "%{$search}%",
-                'starts_with' => "{$search}%",
-                'ends_with' => "%{$search}",
-                'exact' => $search,
-                default => "%{$search}%"
-            };
-
-            // Ensure boolean is either 'and' or 'or'
-            if (! in_array(strtolower($boolean), ['and', 'or'])) {
-                $boolean = 'and';
-            }
-            $boolean = strtolower($boolean);
-
-            // Comparison operator based on the search type
-            $comparison = $operator === 'exact' ? '=' : 'like';
-
-            return $query->has(
-                relation: 'translations',
-                boolean: $boolean,
-                callback: function ($q) use ($key, $searchValue, $localePriority, $comparison) {
-                    $q->whereIn('locale', $localePriority)
-                        ->when(
-                            is_array($key),
-                            fn ($q) => $q->whereIn('key', $key),
-                            fn ($q) => $q->where('key', $key)
-                        )
-                        ->where('text', $comparison, $searchValue);
-                });
+            return TranslatableScope::applyTranslationSearch($query, $key, $search, $locales, $operator, $boolean);
         });
 
         // Add additional macros for exact, starts_with, and ends_with searches
@@ -131,7 +100,7 @@ class TranslatableScope implements Scope
             string|array|null $locales = null,
             string $boolean = 'and',
         ) {
-            return $query->searchByTranslation($key, $search, $locales, 'exact', $boolean);
+            return TranslatableScope::applyTranslationSearch($query, $key, $search, $locales, 'exact', $boolean);
         });
 
         $builder->macro('searchByTranslationStartsWith', function (
@@ -141,7 +110,7 @@ class TranslatableScope implements Scope
             string|array|null $locales = null,
             string $boolean = 'and',
         ) {
-            return $query->searchByTranslation($key, $search, $locales, 'starts_with', $boolean);
+            return TranslatableScope::applyTranslationSearch($query, $key, $search, $locales, 'starts_with', $boolean);
         });
 
         $builder->macro('searchByTranslationEndsWith', function (
@@ -151,8 +120,59 @@ class TranslatableScope implements Scope
             string|array|null $locales = null,
             string $boolean = 'and',
         ) {
-            return $query->searchByTranslation($key, $search, $locales, 'ends_with', $boolean);
+            return TranslatableScope::applyTranslationSearch($query, $key, $search, $locales, 'ends_with', $boolean);
         });
+    }
+
+    /**
+     * Apply the translation search to the query. The search macros share this
+     * implementation instead of calling each other on the builder, where static
+     * analysis cannot resolve macro methods.
+     *
+     * @param  Builder<*>  $query
+     * @param  string|array<int, string>  $key
+     * @param  string|array<int, string>|null  $locales
+     * @return Builder<*>
+     */
+    public static function applyTranslationSearch(
+        Builder $query,
+        string|array $key,
+        string $search,
+        string|array|null $locales = null,
+        string $operator = 'like',
+        string $boolean = 'and',
+    ): Builder {
+        $localePriority = resolve(LocaleResolver::class)->normalizeLocales($locales);
+
+        $searchValue = match ($operator) {
+            'like' => "%{$search}%",
+            'starts_with' => "{$search}%",
+            'ends_with' => "%{$search}",
+            'exact' => $search,
+            default => "%{$search}%"
+        };
+
+        // Ensure boolean is either 'and' or 'or'
+        if (! in_array(strtolower($boolean), ['and', 'or'])) {
+            $boolean = 'and';
+        }
+        $boolean = strtolower($boolean);
+
+        // Comparison operator based on the search type
+        $comparison = $operator === 'exact' ? '=' : 'like';
+
+        return $query->has(
+            relation: 'translations',
+            boolean: $boolean,
+            callback: function ($q) use ($key, $searchValue, $localePriority, $comparison) {
+                $q->whereIn('locale', $localePriority)
+                    ->when(
+                        is_array($key),
+                        fn ($q) => $q->whereIn('key', $key),
+                        fn ($q) => $q->where('key', $key)
+                    )
+                    ->where('text', $comparison, $searchValue);
+            });
     }
 
     /**
@@ -196,7 +216,7 @@ class TranslatableScope implements Scope
             string|array|null $locales = null,
             string $operator = 'exact'
         ) {
-            $query->searchByTranslation($key, $value, $locales, $operator);
+            TranslatableScope::applyTranslationSearch($query, $key, $value, $locales, $operator);
         });
     }
 

--- a/src/Scopes/TranslatableScope.php
+++ b/src/Scopes/TranslatableScope.php
@@ -4,6 +4,7 @@ namespace mindtwo\LaravelTranslatable\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Scope;
 use mindtwo\LaravelTranslatable\Resolvers\LocaleResolver;
 
 /**
@@ -27,7 +28,7 @@ use mindtwo\LaravelTranslatable\Resolvers\LocaleResolver;
  *
  * @template TModel of \Illuminate\Database\Eloquent\Model
  */
-class TranslatableScope implements \Illuminate\Database\Eloquent\Scope
+class TranslatableScope implements Scope
 {
     /**
      * The extensions to be added to the builder.

--- a/src/Traits/HasTranslations.php
+++ b/src/Traits/HasTranslations.php
@@ -175,11 +175,24 @@ trait HasTranslations
     }
 
     /**
-     * Set or update the translation for the given key and locale.
+     * Set or update the translation for the given key and locale. A null value removes
+     * the translation.
      */
-    public function setTranslation(string $key, string $value, ?string $locale = null): self
+    public function setTranslation(string $key, ?string $value, ?string $locale = null): self
     {
         $locale = $locale ?? $this->getLocaleChain()[0] ?? app()->getLocale();
+
+        // The default locale lives on the model itself — translation rows for it are
+        // never read. The attribute persists with the model's next save().
+        if ($locale === $this->defaultLocaleOnModel()) {
+            $this->setAttribute($key, $value);
+
+            return $this;
+        }
+
+        if ($value === null) {
+            return $this->forgetTranslation($key, $locale);
+        }
 
         $this->translations()->updateOrCreate(
             ['key' => $key, 'locale' => $locale],
@@ -195,25 +208,38 @@ trait HasTranslations
     }
 
     /**
-     * Set multiple translations at once for a given locale.
+     * Set multiple translations at once for a given locale. Null values remove the
+     * translation for their key.
+     *
+     * @param  array<string, string|null>  $translations
      */
     public function setTranslations(array $translations, ?string $locale = null): self
     {
+        foreach ($translations as $key => $value) {
+            $this->setTranslation($key, $value, $locale);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove the translation for the given key and locale. For the default locale
+     * stored on the model itself, the attribute is set to null instead and persists
+     * with the model's next save().
+     */
+    public function forgetTranslation(string $key, ?string $locale = null): self
+    {
         $locale = $locale ?? $this->getLocaleChain()[0] ?? app()->getLocale();
 
-        foreach ($translations as $key => $value) {
-            $this->translations()->updateOrCreate(
-                ['key' => $key, 'locale' => $locale],
-                ['text' => $value]
-            );
+        if ($locale === $this->defaultLocaleOnModel()) {
+            $this->setAttribute($key, null);
+
+            return $this;
         }
 
-        // Update cache directly without forcing full reindex
-        if ($this->translationsMap !== null) {
-            foreach ($translations as $key => $value) {
-                $this->translationsMap[$locale][$key] = $value;
-            }
-        }
+        $this->translations()->where('key', '=', $key)->where('locale', '=', $locale)->delete();
+
+        unset($this->translationsMap[$locale][$key]);
 
         return $this;
     }

--- a/tests/HasTranslationsTest.php
+++ b/tests/HasTranslationsTest.php
@@ -487,3 +487,77 @@ test('searchByTranslation performance with complex fallback chains', function ()
     // Reset locale
     app()->setLocale('en');
 });
+
+test('setTranslation stores a row for a non-default locale', function () {
+    $model = TestModel::create();
+
+    $model->setTranslation('title', 'Deutscher Titel', 'de');
+
+    expect($model->translations()->where('locale', 'de')->where('key', 'title')->value('text'))
+        ->toBe('Deutscher Titel');
+});
+
+test('setTranslation with null removes the translation row', function () {
+    $model = TestModel::create();
+    $model->translations()->create(['key' => 'title', 'locale' => 'de', 'text' => 'Deutscher Titel']);
+
+    $model->setTranslation('title', null, 'de');
+
+    expect($model->translations()->where('locale', 'de')->where('key', 'title')->exists())->toBeFalse();
+});
+
+test('forgetTranslation removes only the given locale row', function () {
+    $model = TestModel::create();
+    $model->translations()->createMany([
+        ['key' => 'title', 'locale' => 'de', 'text' => 'Deutscher Titel'],
+        ['key' => 'title', 'locale' => 'fr', 'text' => 'Titre Français'],
+    ]);
+
+    $model->forgetTranslation('title', 'de');
+
+    expect($model->translations()->where('key', 'title')->pluck('locale')->all())->toBe(['fr']);
+});
+
+test('setTranslation writes the default locale to the model itself', function () {
+    config()->set('translatable.default_locale_on_model', true);
+    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+
+    $model = TestModel::create();
+
+    $model->setTranslation('title', 'English Title', 'en');
+
+    expect($model->getUntranslated('title'))->toBe('English Title')
+        ->and($model->translations()->count())->toBe(0);
+
+    $model->save();
+
+    expect(TestModel::query()->first()->getUntranslated('title'))->toBe('English Title');
+});
+
+test('forgetTranslation clears the default locale on the model itself', function () {
+    config()->set('translatable.default_locale_on_model', true);
+    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+
+    $model = TestModel::create(['title' => 'English Title']);
+
+    $model->forgetTranslation('title', 'en');
+
+    expect($model->getUntranslated('title'))->toBeNull()
+        ->and($model->translations()->count())->toBe(0);
+});
+
+test('setTranslations routes values per locale and removes nulls', function () {
+    config()->set('translatable.default_locale_on_model', true);
+    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+
+    $model = TestModel::create();
+    $model->translations()->create(['key' => 'description', 'locale' => 'de', 'text' => 'Alte Beschreibung']);
+
+    $model->setTranslations(['title' => 'English Title', 'description' => 'English Description'], 'en');
+    $model->setTranslations(['title' => 'Deutscher Titel', 'description' => null], 'de');
+
+    expect($model->getUntranslated('title'))->toBe('English Title')
+        ->and($model->getUntranslated('description'))->toBe('English Description')
+        ->and($model->translations()->where('locale', 'de')->pluck('text', 'key')->all())
+        ->toBe(['title' => 'Deutscher Titel']);
+});

--- a/tests/HasTranslationsTest.php
+++ b/tests/HasTranslationsTest.php
@@ -520,7 +520,7 @@ test('forgetTranslation removes only the given locale row', function () {
 
 test('setTranslation writes the default locale to the model itself', function () {
     config()->set('translatable.default_locale_on_model', true);
-    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+    resolve(LocaleResolver::class)->setDefaultLocale('en');
 
     $model = TestModel::create();
 
@@ -536,7 +536,7 @@ test('setTranslation writes the default locale to the model itself', function ()
 
 test('forgetTranslation clears the default locale on the model itself', function () {
     config()->set('translatable.default_locale_on_model', true);
-    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+    resolve(LocaleResolver::class)->setDefaultLocale('en');
 
     $model = TestModel::create(['title' => 'English Title']);
 
@@ -548,7 +548,7 @@ test('forgetTranslation clears the default locale on the model itself', function
 
 test('setTranslations routes values per locale and removes nulls', function () {
     config()->set('translatable.default_locale_on_model', true);
-    resolve(\mindtwo\LaravelTranslatable\Resolvers\LocaleResolver::class)->setDefaultLocale('en');
+    resolve(LocaleResolver::class)->setDefaultLocale('en');
 
     $model = TestModel::create();
     $model->translations()->create(['key' => 'description', 'locale' => 'de', 'text' => 'Alte Beschreibung']);


### PR DESCRIPTION
## What

- `setTranslation()` now accepts `null` to remove a translation, and — with `default_locale_on_model` enabled — routes writes for the default locale to the model attribute instead of creating a translation row.
- New `forgetTranslation($key, $locale)`: deletes the translation row (and prunes the in-memory map); for the default locale it nulls the model attribute instead.
- `setTranslations()` delegates to `setTranslation()` per key, so mixed arrays with `null` values work.

## Why

Under `default_locale_on_model`, `getTranslation()` resolves the default locale exclusively from the model's own column — a translation row for that locale is dead data that is never read. Until now every consumer that writes per-locale content (e.g. app-teach's new topic edit API) had to reimplement the routing plus manual row deletion, because the trait offered no removal method and `setTranslation()` required a non-null string.

## Behavior change (minor version note)

Previously, `setTranslation()` with the default locale silently wrote one of those never-read rows. It now sets the attribute, which persists with the model's next `save()` — the asymmetry (rows persist immediately, default-locale writes on save) is documented on the methods and in the README. Checked downstream consumers: `mindtwo/translatable-fields` writes rows directly (unaffected); `mindtwo/laravel-auto-translatable`'s adapter only calls `setTranslation()` for target locales, never the source.

## How to test

- [ ] `composer test` — 23 passing (6 new: row store, null-removes, forget, default-locale routing for set/forget, mixed `setTranslations`)
- [ ] `vendor/bin/phpstan analyse` clean, pint clean

## Notes

Follow-up in app-teach once released: `TopicUpdateService::applyTranslatableFields()` collapses to a single `setTranslations()` call.